### PR TITLE
[MM-35229] Add ability for deployer to use the same bundle bucket for staging and prod apps.

### DIFF
--- a/internal/tools/aws/s3.go
+++ b/internal/tools/aws/s3.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -134,7 +135,7 @@ func IsBundleDeployed(bucketName, objectKey string, session *session.Session) (b
 	}
 
 	for _, tag := range result.TagSet {
-		if *tag.Key == "deployed" && *tag.Value == "true" {
+		if *tag.Key == fmt.Sprintf("deployed_%s", os.Getenv("Environment")) && *tag.Value == "true" {
 			return true, nil
 		}
 	}
@@ -152,7 +153,7 @@ func PutDeployedObjectTag(bucketName, objectKey string, session *session.Session
 		Tagging: &s3.Tagging{
 			TagSet: []*s3.Tag{
 				{
-					Key:   aws.String("deployed"),
+					Key:   aws.String(fmt.Sprintf("deployed_%s", os.Getenv("Environment"))),
 					Value: aws.String("true"),
 				},
 			},


### PR DESCRIPTION
#### Summary
The previous code was assuming that one bucket per environment is used when tagging a bundle as deployed. Therefore if the bundle was deployed in staging for example was marked as deployed and was never deployed in production. With this fix each bundle gets a per environment tag, therefore the same bundle can be deployed in multiple envs.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-35229

