### PR TITLE
Update AWS tool to use NewSession over New for STS

### DIFF
--- a/internal/tools/aws/iam.go
+++ b/internal/tools/aws/iam.go
@@ -11,7 +11,12 @@ import (
 
 // GetAssumeRoleSession assumes an IAM role and returns the session.
 func GetAssumeRoleSession(iamRole string) (*session.Session, error) {
-	svcSTS := sts.New(session.New())
+	s, err := session.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	svcSTS := sts.New(s)
 
 	input := &sts.AssumeRoleInput{
 		RoleArn:         aws.String(iamRole),


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Update AWS tool to use NewSession over New for STS

We need to update this away from the deprecated `New` function as it does not invoke NewWebIdentityCredentials unless AWS_SDK_LOAD_CONFIG is set.
https://github.com/aws/aws-sdk-go/issues/2828

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/CLD-5553
